### PR TITLE
Removed METHOD as a required variable

### DIFF
--- a/sspush
+++ b/sspush
@@ -213,7 +213,6 @@ conf_var_check () {
     : "${PORT:?$msg}" 
     : "${SERVER:?$msg}" 
     : "${BASELINK:?$msg}" 
-    : "${METHOD:?$msg}"
     : "${NOTIFICATIONS:?$msg}" 
     : "${CLIPBOARD:?$msg}" 
 }


### PR DESCRIPTION
Removed METHOD as a required variable. METHOD only needs to be set in very specific situations per the explanation in the default configuration file.